### PR TITLE
Change dns information source to basic pillar.

### DIFF
--- a/bind/reactor/node_register.sls
+++ b/bind/reactor/node_register.sls
@@ -1,9 +1,9 @@
 {%- from "bind/map.jinja" import client with context %}
-{%- for record in data.data.grains.get('dns_records', []) %}
+{%- for rec_name, record in data.data.get('net_info', {}).iteritems() %}
 {%- for name in record.get('names', []) if '.' in name %}
 {%- set hostname, domain = name.split('.',1) %}
 
-bind_node_register_{{ name }}:
+bind_node_register_{{ name }}_{{ loop.index }}:
   local.ddns.add_host:
   - tgt: bind:server:zone:{{ domain }}:type:master
   - tgt_type: pillar

--- a/bind/register.sls
+++ b/bind/register.sls
@@ -1,5 +1,4 @@
-send_register_event:
+send_dns_register_event:
   event.send:
   - name: dns/node/register
-  - with_grains:
-    - dns_records
+  - net_info: {{ pillar.linux.network.get('host', {}) }}


### PR DESCRIPTION
Names and IPs for minion registering in DNS were pulled from grains, but here they were artifically created by salt.minion state run.
Now the DNS data are pulled from basic information in pillar, so it's not dependent on salt.minion state run beforehand.